### PR TITLE
Fix XYZ(xdao) message passing

### DIFF
--- a/contracts/xyz/XYZBroadcaster.vy
+++ b/contracts/xyz/XYZBroadcaster.vy
@@ -7,6 +7,7 @@
 @custom:security security@curve.fi
 """
 
+version: public(constant(String[8])) = "0.0.2"
 
 event Broadcast:
     agent: indexed(Agent)

--- a/contracts/xyz/XYZBroadcaster.vy
+++ b/contracts/xyz/XYZBroadcaster.vy
@@ -95,9 +95,9 @@ def broadcast(_chain_id: uint256, _messages: DynArray[Message, MAX_MESSAGES], _t
 
     self.digest[agent][_chain_id][nonce] = digest
     self.nonce[agent][_chain_id] = nonce + 1
-    self.deadline[agent][_chain_id][nonce] = block.timestamp + _ttl
+    self.deadline[agent][_chain_id][nonce] = block.timestamp + ttl
 
-    log Broadcast(agent, _chain_id, nonce, digest, block.timestamp + _ttl)
+    log Broadcast(agent, _chain_id, nonce, digest, block.timestamp + ttl)
 
 
 @external

--- a/contracts/xyz/XYZBroadcaster.vy
+++ b/contracts/xyz/XYZBroadcaster.vy
@@ -73,7 +73,7 @@ def broadcast(_chain_id: uint256, _messages: DynArray[Message, MAX_MESSAGES], _t
     @param _ttl Time-to-leave for message if it's not executed.
     """
     agent: Agent = self.agent[msg.sender]
-    assert agent != empty(Agent)
+    assert agent != empty(Agent) and len(_messages) > 0
     if agent != Agent.EMERGENCY:  # Emergency votes should be emergent
         assert 86400 <= _ttl
     assert _ttl <= 21 * 86400

--- a/contracts/xyz/XYZBroadcaster.vy
+++ b/contracts/xyz/XYZBroadcaster.vy
@@ -2,6 +2,9 @@
 """
 @title XYZ Broadcaster
 @author CurveFi
+@license MIT
+@custom:version 0.0.2
+@custom:security security@curve.fi
 """
 
 


### PR DESCRIPTION
In current xdao implementation, if you pass a failing message nonce will stuck and all access to contracts will be lost. Added deadline(`ttl`) for message execution, so one can simple increment nonce and execute following messages.

This contract will be used in some other deployments like sonic with its' native blockhash feed.